### PR TITLE
Web App OS clarified in better way

### DIFF
--- a/docs/Infrastructure_as_code/LabDescription.md
+++ b/docs/Infrastructure_as_code/LabDescription.md
@@ -10,6 +10,8 @@ Once an approver approves the `staging` slot, the app will be deployed to the pr
 **Complete the [Continuous Integration Lab](../Continuous_Integration/LabDescription.md).**
 This lab will setup the Continuous Integration (CI) build.
 
+> IMPORTANT Note: Earlier in the lab you created the Web App Service which is inside a Resource Group which has a name. Ensure that you use a **different** *Resource Group Name* from the one you already have. The other option is to remove the existing Resource Group.
+
 ## Task 1: Explore the ARM Template to deploy the application infrastructure
 
 Navigate to the **Repos** Hub and open the **deployment/Templates/FullEnvironmentSetupMerged.json** file, this file contains the full ARM template for the Parts Unlimited Application.

--- a/docs/Intro_Release_Pipeline/AZURE-APPSERVICE.md
+++ b/docs/Intro_Release_Pipeline/AZURE-APPSERVICE.md
@@ -39,6 +39,8 @@ Since this needs to be a globally unique name, an option is to include the name 
 
 **Operating System**: Currently for .NET Core 2.0 only Linux can be chosen. Later .NET Core Frameworks can also be run on Windows Instances.
 
+> Note: Later on in the lab you will recreate a Web App Service using Infrastructure as Code. Using this technology, you can still run .NET Core 2.0 Web Apps on Windows.
+
 **Region**: West Europe delivers lowest network latency (as the datacenter is located in Amsterdam)
 
 **Linux Plan (West Europe)**: Leave the name of the plan like it is.


### PR DESCRIPTION
It was unclear in the lab that initially a Linux Web App Service is created and during the Infra as Code lab, a Windows Web App Service is created. When the Resource Group Name is the same in both instances, then an error occurs during application of the ARM template.